### PR TITLE
fix: 修复 Mac ARM 上加载示例功能的多个问题

### DIFF
--- a/electron/logger.js
+++ b/electron/logger.js
@@ -41,8 +41,30 @@ function initLogger(appDataPath) {
     return electronLog.transports.file.getFile().path;
 }
 
+// 注册 IPC handler，允许渲染进程发送日志到主进程
+function registerLoggerHandlers() {
+    const { ipcMain } = require('electron');
+    
+    // 处理来自渲染进程的日志
+    ipcMain.handle('log-error', (event, message, error) => {
+        const errorMessage = error 
+            ? `${message}: ${error.message || error}${error.stack ? '\n' + error.stack : ''}`
+            : message;
+        electronLog.error('[渲染进程]', errorMessage);
+    });
+    
+    ipcMain.handle('log-warn', (event, message) => {
+        electronLog.warn('[渲染进程]', message);
+    });
+    
+    ipcMain.handle('log-info', (event, message) => {
+        electronLog.info('[渲染进程]', message);
+    });
+}
+
 module.exports = {
     initLogger,
+    registerLoggerHandlers,
     // 导出日志对象，方便在其他地方直接使用
     log: electronLog
 };

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -528,5 +528,20 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
   base64: {
     atob: (b64String) => Buffer.from(b64String, 'base64').toString('binary'),
+  },
+  // 日志 API - 将渲染进程的日志发送到主进程记录
+  log: {
+    error: (message, error) => {
+      ipcRenderer.invoke('log-error', message, error ? {
+        message: error.message || String(error),
+        stack: error.stack
+      } : null);
+    },
+    warn: (message) => {
+      ipcRenderer.invoke('log-warn', message);
+    },
+    info: (message) => {
+      ipcRenderer.invoke('log-info', message);
+    }
   }
 });

--- a/src/app/pages/playground/subject-item/subject-item.component.ts
+++ b/src/app/pages/playground/subject-item/subject-item.component.ts
@@ -11,6 +11,7 @@ import { CmdService } from '../../../services/cmd.service';
 import { CrossPlatformCmdService } from '../../../services/cross-platform-cmd.service';
 import { PlaygroundService } from '../playground.service';
 import { UiService } from '../../../services/ui.service';
+import { PlatformService } from '../../../services/platform.service';
 
 @Component({
   selector: 'app-subject-item',
@@ -45,7 +46,8 @@ export class SubjectItemComponent {
     private cmdService: CmdService,
     private crossPlatformCmdService: CrossPlatformCmdService,
     private playgroundService: PlaygroundService,
-    private uiService: UiService
+    private uiService: UiService,
+    private platformService: PlatformService
   ) { }
 
   ngOnInit() {
@@ -102,7 +104,8 @@ export class SubjectItemComponent {
       // 将path路径中的最后文件夹名添加"_`generateDateString()`"后缀
       const lastFolderName = path.split('/').pop();
       const targetPathName = this.projectService.generateUniqueProjectName(this.projectService.projectRootPath, lastFolderName + '_');
-      const targetPath = `${this.projectService.projectRootPath}\\${targetPathName}`;
+      const separator = this.platformService.getPlatformSeparator();
+      const targetPath = `${this.projectService.projectRootPath}${separator}${targetPathName}`;
       console.log('目标路径: ', targetPath);
       await this.crossPlatformCmdService.copyItem(examplePath, targetPath, true, true);
       this.uiService.updateFooterState({ state: 'done', text: `示例加载完成` });

--- a/src/app/services/cross-platform-cmd.service.ts
+++ b/src/app/services/cross-platform-cmd.service.ts
@@ -46,16 +46,72 @@ export class CrossPlatformCmdService {
    * @param force 是否强制覆盖
    */
   async copyItem(source: string, destination: string, recursive: boolean = true, force: boolean = true): Promise<any> {
+    // 验证源路径存在
+    if (!window['fs'].existsSync(source)) {
+      throw new Error(`源路径不存在: ${source}`);
+    }
+    
     if (this.platformService.isWindows()) {
       const recursiveFlag = recursive ? '-Recurse' : '';
       const forceFlag = force ? '-Force' : '';
-      return await this.cmdService.runAsync(`Copy-Item -Path "${source}" -Destination "${destination}" ${recursiveFlag} ${forceFlag}`);
+      const result = await this.cmdService.runAsync(`Copy-Item -Path "${source}" -Destination "${destination}" ${recursiveFlag} ${forceFlag}`);
+      
+      // 验证复制结果
+      if (result.type === 'error' || (result.code && result.code !== 0)) {
+        throw new Error(`复制失败: ${result.error || result.data || '未知错误'}`);
+      }
+      
+      // 验证目标路径是否存在
+      if (!window['fs'].existsSync(destination)) {
+        throw new Error(`复制后目标路径不存在: ${destination}`);
+      }
+      
+      return result;
     } else {
+      // Mac/Linux: 使用 cp 命令
+      // 注意：cp -r source destination 的行为：
+      // - 如果 destination 不存在：创建 destination 并复制 source 的内容
+      // - 如果 destination 存在且是目录：将 source 复制到 destination/source
+      // 为了确保行为一致，我们总是确保目标目录的父目录存在，然后复制内容
+      
       const recursiveFlag = recursive ? '-r' : '';
       const forceFlag = force ? '-f' : '';
+      
+      // 确保目标目录的父目录存在
+      const destParent = window['path'].dirname(destination);
+      if (!window['fs'].existsSync(destParent)) {
+        window['fs'].mkdirSync(destParent, { recursive: true });
+      }
+      
+      // 在 Mac/Linux 上，cp -r source destination 的行为：
+      // - 如果 destination 不存在：创建 destination 并复制 source 的内容
+      // - 如果 destination 存在且是目录：将 source 复制到 destination/source（嵌套）
+      // 为了确保行为一致，我们总是先删除目标目录（如果存在），然后复制
+      
+      // 如果目标目录已存在，先删除它（确保干净复制）
+      if (window['fs'].existsSync(destination)) {
+        if (window['fs'].isDirectory(destination)) {
+          window['fs'].rmdirSync(destination, { recursive: true });
+        } else {
+          window['fs'].unlinkSync(destination);
+        }
+      }
+      
+      // 现在目标不存在，直接复制（cp 会创建目标目录并复制内容）
       const escapedSource = this.escapePath(source);
       const escapedDestination = this.escapePath(destination);
-      return await this.cmdService.runAsync(`cp ${recursiveFlag} ${forceFlag} ${escapedSource} ${escapedDestination}`);
+      const result = await this.cmdService.runAsync(`cp ${recursiveFlag} ${forceFlag} ${escapedSource} ${escapedDestination}`);
+      
+      if (result.type === 'error' || (result.code && result.code !== 0)) {
+        throw new Error(`复制失败: ${result.error || result.data || '未知错误'}`);
+      }
+      
+      // 验证目标路径是否存在
+      if (!window['fs'].existsSync(destination)) {
+        throw new Error(`复制后目标路径不存在: ${destination}`);
+      }
+      
+      return result;
     }
   }
 

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -15,6 +15,56 @@ export class PlatformService {
   get za7() {
     return this.isWindows() ? '7za.exe' : '7zz';
   }
+  
+  // 异步获取 7za 完整路径（优先使用环境变量）
+  async getZa7Path(): Promise<string> {
+    try {
+      if ((window as any)?.electronAPI?.env) {
+        const envPath = await (window as any).electronAPI.env.get('AILY_7ZA_PATH');
+        if (envPath) {
+          console.log('从环境变量获取 7za 路径:', envPath);
+          return envPath;
+        } else {
+          console.warn('环境变量 AILY_7ZA_PATH 为空');
+        }
+      } else {
+        console.warn('electronAPI.env 不可用');
+      }
+    } catch (error) {
+      console.warn('无法获取 AILY_7ZA_PATH 环境变量:', error);
+    }
+    
+    // 如果无法获取环境变量，尝试使用相对路径构建
+    // 在开发模式下，child 目录在项目根目录下
+    try {
+      if ((window as any)?.electronAPI?.path) {
+        const electronPath = (window as any).electronAPI.path.getElectronPath();
+        // electronPath 是 electron 目录，需要回到项目根目录
+        const projectRoot = (window as any).electronAPI.path.dirname(electronPath);
+        const childPath = (window as any).electronAPI.path.join(projectRoot, 'child');
+        
+        if (this.isMac()) {
+          const macosPath = (window as any).electronAPI.path.join(childPath, 'macos', '7zz');
+          if ((window as any).electronAPI.path.isExists(macosPath)) {
+            console.log('使用构建的 Mac 路径:', macosPath);
+            return macosPath;
+          }
+        } else if (this.isWindows()) {
+          const windowsPath = (window as any).electronAPI.path.join(childPath, 'windows', '7za.exe');
+          if ((window as any).electronAPI.path.isExists(windowsPath)) {
+            console.log('使用构建的 Windows 路径:', windowsPath);
+            return windowsPath;
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('构建路径失败:', error);
+    }
+    
+    // 最后的备选：返回默认值（假设在 PATH 中）
+    console.warn('使用默认 7za 路径（假设在 PATH 中）');
+    return this.isWindows() ? '7za.exe' : '7zz';
+  }
 
   /**
    * 获取平台路径分隔符


### PR DESCRIPTION
- 修复加载示例按钮一直显示'加载中'的问题（添加完整的错误处理）
- 修复 Mac ARM 上 7zz 路径问题（使用 child/macos/7zz 而不是 child/7zz）
- 修复路径分隔符问题（Mac 上使用正确的路径分隔符）
- 添加渲染进程日志记录功能（通过 IPC 写入主进程日志文件）
- 改进错误处理和日志记录（提供更详细的错误信息）
- 修复 copyItem 在 Mac 上的行为问题（正确处理目标目录已存在的情况）
- 改进解压后的目录结构检测（支持嵌套目录结构）