### PR TITLE
fix(auth): 修复 clearAuthData 缺失 await 及日志级别错误

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -512,7 +512,7 @@ export class AuthService {
         localStorage.setItem(this.USER_INFO_KEY, userInfoStr);
       }
     } catch (error) {
-      console.log('保存用户信息失败:', error);
+      console.error('保存用户信息失败:', error);
     }
   }
 
@@ -579,7 +579,7 @@ export class AuthService {
     localStorage.removeItem(this.TOKEN_KEY);
     localStorage.removeItem(this.REFRESH_TOKEN_KEY);
     localStorage.removeItem(this.USER_INFO_KEY);
-    this.clearAuthDataFile();
+    await this.clearAuthDataFile();
     this.isLoggedInSubject.next(false);
     this.userInfoSubject.next(null);
   }


### PR DESCRIPTION
## Summary

- 添加 `await` 确保 `clearAuthDataFile()` 异步操作完成后再更新状态
- 将 `saveUserInfo` 失败日志从 `console.log` 改为 `console.error`

## Changes

**src/app/services/auth.service.ts**
- Line 515: `console.log` → `console.error`（错误应使用 error 级别）
- Line 582: 添加 `await`（确保文件清理完成后再更新 Subject 状态）

## Test plan

- [ ] 验证登出流程正常工作
- [ ] 验证 saveUserInfo 失败时控制台显示 error 级别日志

🤖 Generated with [Claude Code](https://claude.com/claude-code)