### PR TITLE
对串口选择框使用最小宽度而不是固定宽度

### DIFF
--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -1,6 +1,6 @@
 <div class="menu-container">
   <div class="menu-box bborder sscroll" #menuBox
-    [ngStyle]="{ left: position.x + 'px', top: position.y + 'px', 'width': width ? width + 'px' : 'auto', 'max-height': maxHeight ? maxHeight + 'px' : 'none', 'overflow-y': maxHeight ? 'auto' : 'visible' }">
+    [ngStyle]="{ left: position.x + 'px', top: position.y + 'px', 'width': width ? width + 'px' : 'auto', 'min-width': minWidth ? minWidth + 'px' : 'auto', 'max-height': maxHeight ? maxHeight + 'px' : 'none', 'overflow-y': maxHeight ? 'auto' : 'visible' }">
     @for (item of menuList; track $index) {
     @if (item.sep) {
     <div class="sep"></div>

--- a/src/app/components/menu/menu.component.ts
+++ b/src/app/components/menu/menu.component.ts
@@ -33,6 +33,8 @@ export class MenuComponent {
 
   @Input() width;
 
+  @Input() minWidth;
+
   @Input() maxHeight: number | null = null;
 
   @Output() itemClickEvent = new EventEmitter();

--- a/src/app/tools/serial-monitor/serial-monitor.component.html
+++ b/src/app/tools/serial-monitor/serial-monitor.component.html
@@ -199,7 +199,7 @@
 
 <!-- device port list -->
 @if (showPortList) {
-<app-menu [position]="position" [width]="260" [menuList]="portList" (closeEvent)="closePortList()"
+<app-menu [position]="position" [minWidth]="260" [menuList]="portList" (closeEvent)="closePortList()"
   [keywords]="boardKeywords" (itemClickEvent)="selectPort($event)"></app-menu>
 }
 


### PR DESCRIPTION
虽然全显示了好像也不是很好看，但是比不显示全好一点
<img width="417" height="174" alt="截屏2026-03-10 00 37 20" src="https://github.com/user-attachments/assets/da4ad3b7-6ff7-4b75-a895-c0f903ac9951" />
<img width="522" height="181" alt="截屏2026-03-10 00 47 02" src="https://github.com/user-attachments/assets/409b304b-630e-4214-8191-9a8f286bf861" />
